### PR TITLE
Add build date as suffix to the version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ install:
 	$(SUDO) mv binary/boot/filesystem.dir/* $(DESTDIR)/
 	# only copy the manifest file if we are in a launchpad buildd
 	set -e ; if [ -e /build/core ]; then \
-	  TARGET_BASENAME=/build/core/core_16-$$(cat $(DESTDIR)/usr/lib/snapd/info|cut -f2 -d=|cut -f1 -d~|cut -b1-29)_$(DPKG_ARCH); \
+	  TARGET_BASENAME=/build/core/core_16-$$(cat $(DESTDIR)/usr/lib/snapd/info|cut -f2 -d=|cut -f1 -d~|cut -b1-29)_$(DPKG_ARCH)-$$(/bin/date +%Y%m%d); \
 	  $(SUDO) mv livecd.ubuntu-core.manifest "$${TARGET_BASENAME}".manifest;  \
 	  $(SUDO) cp /build/core/parts/livebuild/install/usr/share/snappy/dpkg.yaml "$${TARGET_BASENAME}".dpkg.yaml; \
 	  ls -lah /build/core; \

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -2,7 +2,7 @@ name: core
 version: 16-2
 version-script: |
     # remember to keep version script in sync with "Makefile"
-    echo "16-$(grep ^VERSION= prime/usr/lib/snapd/info |cut -f2 -d=| sed s/~ubuntu.*// | cut -b1-29)"
+    echo "16-$(grep ^VERSION= prime/usr/lib/snapd/info |cut -f2 -d=| sed s/~ubuntu.*// | cut -b1-29)-$(/bin/date +%Y%m%d)"
 summary: snapd runtime environment
 description: The core runtime environment for snapd
 confinement: strict


### PR DESCRIPTION
So we follow the same conventions as in core18+ bases.